### PR TITLE
Abstrakte Listener für die LibreOffice-Listener

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/SimpleDialogLayout.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/SimpleDialogLayout.java
@@ -15,7 +15,6 @@ import com.sun.star.awt.XControl;
 import com.sun.star.awt.XControlContainer;
 import com.sun.star.awt.XControlModel;
 import com.sun.star.awt.XWindow;
-import com.sun.star.awt.XWindowListener;
 import com.sun.star.beans.PropertyVetoException;
 import com.sun.star.beans.XMultiPropertySet;
 import com.sun.star.lang.EventObject;
@@ -28,8 +27,9 @@ import de.muenchen.allg.afid.UNO;
 import de.muenchen.allg.itd51.wollmux.core.dialog.ControlModel.Align;
 import de.muenchen.allg.itd51.wollmux.core.dialog.ControlModel.Dock;
 import de.muenchen.allg.itd51.wollmux.core.dialog.ControlModel.Orientation;
+import de.muenchen.allg.itd51.wollmux.core.dialog.adapter.AbstractWindowListener;
 
-public class SimpleDialogLayout implements XWindowListener
+public class SimpleDialogLayout extends AbstractWindowListener
 {
   private static final Logger LOGGER = LoggerFactory
       .getLogger(SimpleDialogLayout.class);
@@ -376,24 +376,6 @@ public class SimpleDialogLayout implements XWindowListener
     }
 
     return this.containerWindow;
-  }
-
-  @Override
-  public void disposing(EventObject arg0)
-  {
-    // ...
-  }
-
-  @Override
-  public void windowHidden(EventObject arg0)
-  {
-    // ...
-  }
-
-  @Override
-  public void windowMoved(WindowEvent arg0)
-  {
-    // ...
   }
 
   @Override

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractActionListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractActionListener.java
@@ -1,0 +1,15 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.XActionListener;
+import com.sun.star.lang.EventObject;
+
+@FunctionalInterface
+public interface AbstractActionListener extends XActionListener
+{
+
+  @Override
+  public default void disposing(EventObject event)
+  {
+    // default implementation
+  }
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractFocusListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractFocusListener.java
@@ -1,0 +1,28 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.FocusEvent;
+import com.sun.star.awt.XFocusListener;
+import com.sun.star.lang.EventObject;
+
+public abstract class AbstractFocusListener implements XFocusListener
+{
+
+  @Override
+  public void disposing(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void focusGained(FocusEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void focusLost(FocusEvent event)
+  {
+    // default implementation
+  }
+
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractItemListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractItemListener.java
@@ -1,0 +1,14 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.XItemListener;
+import com.sun.star.lang.EventObject;
+
+@FunctionalInterface
+public interface AbstractItemListener extends XItemListener
+{
+  @Override
+  default void disposing(EventObject event)
+  {
+    // default implementation
+  }
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractMenuListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractMenuListener.java
@@ -1,0 +1,39 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.MenuEvent;
+import com.sun.star.awt.XMenuListener;
+import com.sun.star.lang.EventObject;
+
+public abstract class AbstractMenuListener implements XMenuListener
+{
+
+  @Override
+  public void disposing(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void itemActivated(MenuEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void itemDeactivated(MenuEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void itemHighlighted(MenuEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void itemSelected(MenuEvent event)
+  {
+    // default implementation
+  }
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractMouseListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractMouseListener.java
@@ -1,0 +1,40 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.MouseEvent;
+import com.sun.star.awt.XMouseListener;
+import com.sun.star.lang.EventObject;
+
+public abstract class AbstractMouseListener implements XMouseListener
+{
+
+  @Override
+  public void disposing(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void mouseEntered(MouseEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void mouseExited(MouseEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void mousePressed(MouseEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void mouseReleased(MouseEvent event)
+  {
+    // default implementation
+  }
+
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractSpinListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractSpinListener.java
@@ -1,0 +1,40 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.SpinEvent;
+import com.sun.star.awt.XSpinListener;
+import com.sun.star.lang.EventObject;
+
+public abstract class AbstractSpinListener implements XSpinListener
+{
+
+  @Override
+  public void disposing(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void down(SpinEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void first(SpinEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void last(SpinEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void up(SpinEvent event)
+  {
+    // default implementation
+  }
+
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractTextListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractTextListener.java
@@ -1,0 +1,14 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.XTextListener;
+import com.sun.star.lang.EventObject;
+
+@FunctionalInterface
+public interface AbstractTextListener extends XTextListener
+{
+  @Override
+  default void disposing(EventObject event)
+  {
+    // default implementation
+  }
+}

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractWindowListener.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/adapter/AbstractWindowListener.java
@@ -1,0 +1,40 @@
+package de.muenchen.allg.itd51.wollmux.core.dialog.adapter;
+
+import com.sun.star.awt.WindowEvent;
+import com.sun.star.awt.XWindowListener;
+import com.sun.star.lang.EventObject;
+
+public abstract class AbstractWindowListener implements XWindowListener
+{
+
+  @Override
+  public void disposing(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void windowHidden(EventObject event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void windowMoved(WindowEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void windowResized(WindowEvent event)
+  {
+    // default implementation
+  }
+
+  @Override
+  public void windowShown(EventObject event)
+  {
+    // default implementation
+  }
+
+}


### PR DESCRIPTION
Jede Methode enthält eine leere default-Implementierung, so dass
nur noch die gewünschten Methoden überschrieben werden müssen.