### PR TITLE
trac#30703 No save dialog

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFReadLegacyModeDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFReadLegacyModeDataContainer.java
@@ -76,22 +76,39 @@ public class RDFReadLegacyModeDataContainer implements
   /**
    * Stellt sicher, dass dataId aus den Notizen gelöscht wurde, bzw. löscht das
    * Element falls es noch nicht gelöscht wurde.
-   * 
+   *
    * @author Christoph Lutz (D-III-ITD-D101) TESTED
    */
   private void ensureRemovedFromLegacy(DataID dataId)
   {
     if (!removedFromLegacy.contains(dataId))
     {
+      XModifiable mod = UNO.XModifiable(doc);
+      boolean modState = false;
+      if (mod != null)
+      {
+        modState = mod.isModified();
+      }
+
       removedFromLegacy.add(dataId);
       legacy.removeData(dataId);
+
+      if (mod != null)
+      {
+        try
+        {
+          mod.setModified(modState);
+        } catch (Exception e)
+        {
+        }
+      }
     }
   }
 
   /**
    * Ruft c.setData(dataId, data) auf, wobei der Modified-Status des Dokuments
    * unangetastet bleibt.
-   * 
+   *
    * @author Christoph Lutz (D-III-ITD-D101) TESTED
    */
   private void copyOnRead(PersistentDataContainer c, DataID dataId, String data)


### PR DESCRIPTION
old documents used comments for saving additional WollMux
data, like gui description. In mode RDF-Read-Legacy these
comments are moved into the RDF file. This changes causes
the save dialog to open, although there is no visible change
for the user. So the modified state should be reset.