### PR TITLE
trac#30717 allow undefined values in dropdowns

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/form/model/Control.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/form/model/Control.java
@@ -296,23 +296,14 @@ public class Control
   }
 
   /**
-   * Setzt den Wert des Formularelementes, berechnet die Sichtbarkeiten neu und informartiert die
-   * Listener.
+   * Setzt den Wert des Formularelementes.
    *
    * @param value
    *          Der neue Wert.
-   * @param values
-   *          Die neuen Werte des Models.
    */
   public void setValue(String value)
   {
-    if (options != null && !options.isEmpty() && !options.contains(value))
-    {
-      this.value = options.get(0);
-    } else
-    {
-      this.value = value;
-    }
+    this.value = value;
   }
 
   /**


### PR DESCRIPTION
WollMux dropdowns can be editable but only predefined values
were copied to the document. So do not check if a value is in
the options list of a dropdown.