### PR TITLE
trac#31069 tab inactive although there are visible elements

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/controls/UIElement.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/controls/UIElement.java
@@ -160,12 +160,12 @@ public interface UIElement extends Value
    */
   public void setBackground(Color bg);
 
-  public void setEnabled(boolean enabled);
+  public boolean setEnabled(boolean enabled);
 
   /**
    * Setzt die Sichtbarkeit der Komponente und ihres Zusatzlabels (falls vorhanden).
    */
-  public void setVisible(boolean vis);
+  public boolean setVisible(boolean vis);
 
   /**
    * Liefert true, wenn das Element keine Änderungen erlaubt (z,B, ein Separator oder

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/controls/UIElementBase.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/dialog/controls/UIElementBase.java
@@ -52,9 +52,11 @@ public abstract class UIElementBase implements UIElement
   }
 
   @Override
-  public void setEnabled(boolean enabled)
+  public boolean setEnabled(boolean enabled)
   {
+    boolean oldState = getComponent().isEnabled();
     this.getComponent().setEnabled(enabled);
+    return oldState != enabled;
   }
 
   @Override
@@ -94,8 +96,9 @@ public abstract class UIElementBase implements UIElement
   }
 
   @Override
-  public void setVisible(boolean vis)
+  public boolean setVisible(boolean vis)
   {
+    boolean oldState = getComponent().isVisible();
     if (getLabel() != null)
     {
       getLabel().setVisible(vis);
@@ -106,6 +109,7 @@ public abstract class UIElementBase implements UIElement
      * http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4403550
      */
     ((JComponent) getComponent().getParent()).revalidate();
+    return oldState != vis;
   }
 
   @Override


### PR DESCRIPTION
If elements are in several visiblity groups and they all change their state,
the number of visible elements per tab is decreased several times per element.
Now we only decrease if the state of an element has really changed and not always.