### PR TITLE
trac#34245: Pasting RTF formatted text destroy's formular description.

### DIFF
--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/AnnotationBasedPersistentDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/AnnotationBasedPersistentDataContainer.java
@@ -317,4 +317,16 @@ public class AnnotationBasedPersistentDataContainer implements
   {
     //
   }
+
+  @Override
+  public boolean isWollmuxDatenGraphNull()
+  {
+    return false;
+  }
+
+  @Override
+  public void retoreWollmuxDatenGraph(String Formularwerte, String WollMuxVersion, String OOoVersion)
+  {
+    //
+  }
 }

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/PersistentDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/PersistentDataContainer.java
@@ -87,6 +87,17 @@ public interface PersistentDataContainer
   public void flush();
 
   /**
+   * Gibt Auskunft darüber, ob der WollmuxDatenGraph zerstört wurde. Falls ja, wird
+   * mit den Formularwerten neu initialisiert.
+   */
+  public boolean isWollmuxDatenGraphNull();
+
+  /**
+   * Falls der WollmuxDatenGraph zerstört wurde, werden die Formularwerten neu initialisiert.
+   */
+  public void retoreWollmuxDatenGraph(String Formularwerte, String WollMuxVersion, String OOoVersion);
+
+  /**
    * Liste aller möglichen DataIDs des WollMux.
    *
    * @author Christoph Lutz (D-III-ITD-D101)

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFBasedPersistentDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFBasedPersistentDataContainer.java
@@ -293,4 +293,46 @@ public class RDFBasedPersistentDataContainer implements
       LOGGER.error(L.m("Kann RDF-Metadaten nicht persistieren."), e);
     }
   }
+
+  @Override
+  public boolean isWollmuxDatenGraphNull()
+  {
+    XNamedGraph g = getWollMuxDatenGraph();
+    return (g==null);
+  }
+
+  @Override
+  public void retoreWollmuxDatenGraph(String Formularwerte, String WollMuxVersion, String OOoVersion)
+  {
+    try
+    {
+      XNamedGraph g = getWollMuxDatenGraph();
+      if(g==null)
+      {
+        //Workaround, der Fehler liegt in libreoffice:
+        //Wollmuxdaten werden im Dokument durch Einfügen von RTF-formatiertem Text gelöscht.
+        //Daher werden die Wollmuxdaten neu aufgebaut
+        xDMA = UNO.XDocumentMetadataAccess(doc);
+        if (xDMA == null) {
+          throw new RDFMetadataNotSupportedException();
+        }
+        xRepos = xDMA.getRDFRepository();
+        wollmuxDatenURI = URI.create(UNO.defaultContext, WOLLMUX_DATEN_URI_STR);
+        getOrCreateWollMuxDatenGraph();
+
+        setData(DataID.SETTYPE, "formDocument");
+        setData(DataID.TOUCH_WOLLMUXVERSION, WollMuxVersion);
+        setData(DataID.TOUCH_OOOVERSION, OOoVersion);
+        setData(DataID.FORMULARWERTE, Formularwerte);
+        //documentController.storeCurrentFormDescription();
+      }
+
+      xDMA.storeMetadataToStorage(UNO.XStorageBasedDocument(doc).getDocumentStorage());
+    }
+    catch (Exception e)
+    {
+      LOGGER.error(L.m("Kann RDF-Metadaten nicht persistieren."), e);
+    }
+  }
+
 }

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFReadLegacyModeDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/RDFReadLegacyModeDataContainer.java
@@ -161,6 +161,18 @@ public class RDFReadLegacyModeDataContainer implements
     legacy.flush();
   }
 
+  @Override
+  public boolean isWollmuxDatenGraphNull()
+  {
+    return rdfData.isWollmuxDatenGraphNull();
+  }
+
+  @Override
+  public void retoreWollmuxDatenGraph(String Formularwerte, String WollMuxVersion, String OOoVersion)
+  {
+	rdfData.retoreWollmuxDatenGraph(Formularwerte, WollMuxVersion, OOoVersion);
+  }
+
   /*
    * (non-Javadoc)
    * 

--- a/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/TransitionModeDataContainer.java
+++ b/src/main/java/de/muenchen/allg/itd51/wollmux/core/document/TransitionModeDataContainer.java
@@ -131,6 +131,18 @@ public class TransitionModeDataContainer implements
     legacy.flush();
   }
 
+  @Override
+  public boolean isWollmuxDatenGraphNull()
+  {
+    return rdfData.isWollmuxDatenGraphNull();
+  }
+
+  @Override
+  public void retoreWollmuxDatenGraph(String Formularwerte, String WollMuxVersion, String OOoVersion)
+  {
+	rdfData.retoreWollmuxDatenGraph(Formularwerte, WollMuxVersion, OOoVersion);
+  }
+
   /*
    * (non-Javadoc)
    *


### PR DESCRIPTION
Adapted from solution in 18.2, as 18.1 has the same problem, see 18.2 PR#368.